### PR TITLE
Feature/separate future and past

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,12 +1,18 @@
 class UsersController < ApplicationController
 
   def index
-    
+
   end
 
   def show
     @user = User.find(params[:id])
-    @meals = @user.meals
-    @events = @user.events
+
+    @meals = @user.get_sorted_meals
+    @past_meals = @meals[:past]
+    @future_meals = @meals[:future]
+
+    @events = @user.get_sorted_events
+    @future_events = @events[:past]
+    @past_events = @events[:future]
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,8 +11,9 @@ class UsersController < ApplicationController
     @past_meals = @meals[:past]
     @future_meals = @meals[:future]
 
-    @events = @user.get_sorted_events
-    @future_events = @events[:past]
-    @past_events = @events[:future]
+    @events = @user.events
+    #@events = @user.get_sorted_events
+    #@future_events = @events[:past]
+    #@past_events = @events[:future]
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,9 +11,8 @@ class UsersController < ApplicationController
     @past_meals = @meals[:past]
     @future_meals = @meals[:future]
 
-    @events = @user.events
-    #@events = @user.get_sorted_events
-    #@future_events = @events[:past]
-    #@past_events = @events[:future]
+    @events = @user.get_sorted_events
+    @future_events = @events[:future]
+    @past_events = @events[:past]
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,4 +20,27 @@ class User < ActiveRecord::Base
       user.password = Devise.friendly_token[0,20]
     end
   end
+
+  # The two methods below are nearly identical and can probably be refactored into
+  # one pretty nicely. Especially if something similar will be done a third time.
+  # If you do this ^ don't forget to update UsersController as well :)
+  def get_sorted_meals
+    meals = self.meals
+    sorted_result = {
+      future: meals.where("date > ?", Time.now),
+      past: meals.where("date < ?", Time.now)
+    }
+
+    return sorted_result
+  end
+
+  def get_sorted_events
+    events = self.events
+    sorted_result = {
+      future: events.where("date > ?", Time.now),
+      past: events.where("date < ?", Time.now)
+    }
+
+    return sorted_result
+  end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,133 +1,133 @@
 <div class="main-container" style="margin: auto;">
   <div class="container-fluid">
-    <div class="spacer">
-      <div class="row">
-        <div class="col-md-12 col-sm-12 col-xs-12"> 
-          <div class="current-profile">
-            <div class="user-bg"></div>
-            <%= image_tag(@user.image, :class => "user-pic") %>
-            <div class="user-details">
-              <h4 class="user-name"><%= @user.name %></h4>
-              <h5 class="description"></h5>
-            </div>
-          </br>
-            <div class= "row">
-              <div class= "col-lg-6 col-md-6 col-sm-12 col-xs-12">
-                <div class="blog blog-info">
-                  <div class="blog-header">
-                    <h5 class="blog-title">Attending:</h5>
+    <div class="row">
+      <div class="col-md-12 col-sm-12 col-xs-12">
+        <div class="current-profile">
+          <div class="user-bg"></div>
+          <%= image_tag(@user.image, :class => "user-pic") %>
+          <div class="user-details">
+            <h4 class="user-name"><%= @user.name %></h4>
+            <h5 class="description"></h5>
+          </div>
+        </div>
+        </br>
+        <div class= "row">
+          <div class= "col-lg-6 col-md-6 col-sm-12 col-xs-12">
+            <div class="blog blog-info">
+              <div class="blog-header">
+                <h5 class="blog-title">Attending:</h5>
+              </div>
+              <div class= "blog-body">
+                <ul class="chats">
+                  <% if @future_meals.empty? %>
+                    <li>Not Attending Any Upcoming Meals!</li>
+                <% end %>
+                  <% @future_meals.each do |meal| %>
+                    <li class="in">
+                  <img class="avatar" alt src="<%= meal.host.image %>">
+                  <div class="message">
+                    <%= link_to meal.name, meal, class: "name" %>
+                    <span class="date-time">
+                      - <%= meal.date.strftime("%A, %B %d, %Y at %l:%M %p") %>
+                  </span>
                   </div>
-                  <div class= "blog-body">
-                      <ul class="chats">
-                        <% if @future_meals.empty? %>
-                          <li>Not Attending Any Upcoming Meals!</li>
-                        <% end %>
-                          <% @future_meals.each do |meal| %>
-                          <li class="in">
-                          <img class="avatar" alt src="<%= meal.host.image %>">
-                          <div class="message">
-                            <%= link_to meal.name, meal, class: "name" %>
-                              <span class="date-time">
-                                  - <%= meal.date.strftime("%A, %B %d, %Y at %l:%M %p") %>
-                              </span>
-                               </div>
-                          </li>
-                          <% unless meal.users.include?(current_user) %>
-                            <%= form_tag(create_user_meal_path, method: :post) %>
-                            <%= hidden_field_tag 'meal_id', meal.id %>
-                            <%= submit_tag "Join This Meal!" %>
-                          <% end %>
-                        <% end %>
-                       </ul>
-                    </div> <!-- closes blog body -->
-                </div> <!-- closes blog blog info-->
-                <div class="blog blog-info">
-                  <div class="blog-header">
-                      <h5 class="blog-title">Already Attended:</h5>
+                  </li>
+                  <% unless meal.users.include?(current_user) %>
+                    <%= form_tag(create_user_meal_path, method: :post) %>
+                  <%= hidden_field_tag 'meal_id', meal.id %>
+                  <%= submit_tag "Join This Meal!" %>
+                <% end %>
+                <% end %>
+                </ul>
+              </div> <!-- closes blog body -->
+            </div> <!-- closes blog blog info-->
+            <div class="blog blog-info">
+              <div class="blog-header">
+                <h5 class="blog-title">Already Attended:</h5>
+              </div>
+              <div class= "blog-body">
+                <ul class="chats">
+                  <% if @past_meals.empty? %>
+                    <li>Has Never Attended Any Meals!</li>
+                <% end %>
+                  <% @past_meals.each do |meal| %>
+                    <li class="in">
+                  <img class="avatar" alt src="<%= meal.host.image %>">
+                  <div class="message">
+                    <%= link_to meal.name, meal, class: "name" %>
+                    <span class="date-time">
+                      - <%= meal.date.strftime("%A, %B %d, %Y at %l:%M %p") %>
+                  </span>
                   </div>
-                  <div class= "blog-body">
-                      <ul class="chats">
-                        <% if @past_meals.empty? %>
-                          <li>Has Never Attended Any Meals!</li>
-                        <% end %>
-                          <% @past_meals.each do |meal| %>
-                          <li class="in">
-                          <img class="avatar" alt src="<%= meal.host.image %>">
-                          <div class="message">
-                            <%= link_to meal.name, meal, class: "name" %>
-                              <span class="date-time">
-                                  - <%= meal.date.strftime("%A, %B %d, %Y at %l:%M %p") %>
-                              </span>
-                               </div>
-                          </li>
-                          <% unless meal.users.include?(current_user) %>
-                            <%= form_tag(create_user_meal_path, method: :post) %>
-                            <%= hidden_field_tag 'meal_id', meal.id %>
-                            <%= submit_tag "Join This Meal!" %>
-                          <% end %>
-                        <% end %>
-                       </ul>
-                    </div> <!-- closes blog body -->
-                </div> <!-- closes blog blog info-->
-              </div> <!-- closes column-->
-              <div class= "col-lg-6 col-md-6 col-sm-12 col-xs-12">
-                <div class="blog blog-info">
-                  <div class="blog-header">
-                    <h5 class="blog-title">Hosting:</h5>
+                  </li>
+                  <% unless meal.users.include?(current_user) %>
+                    <%= form_tag(create_user_meal_path, method: :post) %>
+                  <%= hidden_field_tag 'meal_id', meal.id %>
+                  <%= submit_tag "Join This Meal!" %>
+                <% end %>
+                <% end %>
+                </ul>
+              </div> <!-- closes blog body -->
+            </div> <!-- closes blog blog info-->
+          </div> <!-- closes column-->
+          <div class= "col-lg-6 col-md-6 col-sm-12 col-xs-12">
+            <div class="blog blog-info">
+              <div class="blog-header">
+                <h5 class="blog-title">Hosting:</h5>
+              </div>
+              <div class= "blog-body">
+                <ul class="chats">
+                  <% if @future_events.empty? %>
+                    <li>Not Hosting Any Upcoming Meals!</li>
+                <% end %>
+                  <% @future_events.each do |event| %>
+                    <li class="out">
+                  <div class="message">
+                    <%= link_to event.name, event, class: "name"%>
+                    <span class="date-time">
+                      - <%= event.date.strftime("%A, %B %d, %Y at %l:%M %p") %>
+                  </span>
                   </div>
-                  <div class= "blog-body">
-                    <ul class="chats">
-                      <% if @future_events.empty? %>
-                          <li>Not Hosting Any Upcoming Meals!</li>
-                      <% end %>
-                        <% @future_events.each do |event| %>
-                          <li class="out">
-                          <div class="message">
-                            <%= link_to event.name, event, class: "name"%>
-                            <span class="date-time">
-                               - <%= event.date.strftime("%A, %B %d, %Y at %l:%M %p") %>
-                            </span>
-                          </div>
-                          </li>
-                          <% unless event.users.include?(current_user) || event.host == current_user%>
-                            <%= form_tag(create_user_meal_path, method: :post) %>
-                            <%= hidden_field_tag 'meal_id', event.id %>
-                            <%= submit_tag "Join This Meal!" %>
-                          <% end %>
-                        <% end %>
-                    </ul>
-                  </div> <!-- closes body-->
-                </div> <!-- closes blog blog info-->
-                <div class="blog blog-info">
-                  <div class="blog-header">
-                    <h5 class="blog-title">Already Hosted:</h5>
+                  </li>
+                  <% unless event.users.include?(current_user) || event.host == current_user%>
+                    <%= form_tag(create_user_meal_path, method: :post) %>
+                  <%= hidden_field_tag 'meal_id', event.id %>
+                  <%= submit_tag "Join This Meal!" %>
+                <% end %>
+                <% end %>
+                </ul>
+              </div> <!-- closes body-->
+            </div> <!-- closes blog blog info-->
+            <div class="blog blog-info">
+              <div class="blog-header">
+                <h5 class="blog-title">Already Hosted:</h5>
+              </div>
+              <div class= "blog-body">
+                <ul class="chats">
+                  <% if @past_events.empty? %>
+                    <li>Has Never Hosted Any Meals!</li>
+                <% end %>
+                  <% @past_events.each do |event| %>
+                    <li class="out">
+                  <div class="message">
+                    <%= link_to event.name, event, class: "name"%>
+                    <span class="date-time">
+                      - <%= event.date.strftime("%A, %B %d, %Y at %l:%M %p") %>
+                  </span>
                   </div>
-                  <div class= "blog-body">
-                    <ul class="chats">
-                      <% if @past_events.empty? %>
-                          <li>Has Never Hosted Any Meals!</li>
-                      <% end %>
-                        <% @past_events.each do |event| %>
-                          <li class="out">
-                          <div class="message">
-                            <%= link_to event.name, event, class: "name"%>
-                            <span class="date-time">
-                               - <%= event.date.strftime("%A, %B %d, %Y at %l:%M %p") %>
-                            </span>
-                          </div>
-                          </li>
-                          <% unless event.users.include?(current_user) || event.host == current_user%>
-                            <%= form_tag(create_user_meal_path, method: :post) %>
-                            <%= hidden_field_tag 'meal_id', event.id %>
-                            <%= submit_tag "Join This Meal!" %>
-                          <% end %>
-                        <% end %>
-                    </ul>
-                  </div> <!-- closes body-->
-                </div> <!-- closes blog blog info-->
-              </div> <!-- closes column-->
-          </div> <!-- closes row line 15-->
-        </div>  <!-- closes column line 5-->      
-      </div> <!-- closes row line 4-->
-    </div>
+                  </li>
+                  <% unless event.users.include?(current_user) || event.host == current_user%>
+                    <%= form_tag(create_user_meal_path, method: :post) %>
+                  <%= hidden_field_tag 'meal_id', event.id %>
+                  <%= submit_tag "Join This Meal!" %>
+                <% end %>
+                <% end %>
+                </ul>
+              </div> <!-- closes body-->
+            </div> <!-- closes blog blog info-->
+          </div> <!-- closes column-->
+        </div> <!-- closes row line 15-->
+      </div>  <!-- closes column line 5-->
+    </div> <!-- closes row line 4-->
+  </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -77,10 +77,10 @@
                   </div>
                   <div class= "blog-body">
                     <ul class="chats">
-                      <% if @events.empty? %>
-                          <li>Not Hosting Any Meals!</li>
+                      <% if @future_events.empty? %>
+                          <li>Not Hosting Any Upcoming Meals!</li>
                       <% end %>
-                        <% @events.each do |event| %>
+                        <% @future_events.each do |event| %>
                           <li class="out">
                           <div class="message">
                             <%= link_to event.name, event, class: "name"%>
@@ -96,9 +96,36 @@
                           <% end %>
                         <% end %>
                     </ul>
-                </div> <!-- closes body-->
-              </div> <!-- closes blog blog info-->
-            </div> <!-- closes column-->
+                  </div> <!-- closes body-->
+                </div> <!-- closes blog blog info-->
+                <div class="blog blog-info">
+                  <div class="blog-header">
+                    <h5 class="blog-title">Already Hosted:</h5>
+                  </div>
+                  <div class= "blog-body">
+                    <ul class="chats">
+                      <% if @past_events.empty? %>
+                          <li>Has Never Hosted Any Meals!</li>
+                      <% end %>
+                        <% @past_events.each do |event| %>
+                          <li class="out">
+                          <div class="message">
+                            <%= link_to event.name, event, class: "name"%>
+                            <span class="date-time">
+                               - <%= event.date.strftime("%A, %B %d, %Y at %l:%M %p") %>
+                            </span>
+                          </div>
+                          </li>
+                          <% unless event.users.include?(current_user) || event.host == current_user%>
+                            <%= form_tag(create_user_meal_path, method: :post) %>
+                            <%= hidden_field_tag 'meal_id', event.id %>
+                            <%= submit_tag "Join This Meal!" %>
+                          <% end %>
+                        <% end %>
+                    </ul>
+                  </div> <!-- closes body-->
+                </div> <!-- closes blog blog info-->
+              </div> <!-- closes column-->
           </div> <!-- closes row line 15-->
         </div>  <!-- closes column line 5-->      
       </div> <!-- closes row line 4-->

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -15,14 +15,42 @@
               <div class= "col-lg-6 col-md-6 col-sm-12 col-xs-12">
                 <div class="blog blog-info">
                   <div class="blog-header">
-                      <h5 class="blog-title">Attending:</h5>
+                    <h5 class="blog-title">Attending:</h5>
                   </div>
                   <div class= "blog-body">
                       <ul class="chats">
-                        <% if @meals.empty? %>
-                          <li>Not Attending Any Meals!</li>
+                        <% if @future_meals.empty? %>
+                          <li>Not Attending Any Upcoming Meals!</li>
                         <% end %>
-                          <% @meals.each do |meal| %>
+                          <% @future_meals.each do |meal| %>
+                          <li class="in">
+                          <img class="avatar" alt src="<%= meal.host.image %>">
+                          <div class="message">
+                            <%= link_to meal.name, meal, class: "name" %>
+                              <span class="date-time">
+                                  - <%= meal.date.strftime("%A, %B %d, %Y at %l:%M %p") %>
+                              </span>
+                               </div>
+                          </li>
+                          <% unless meal.users.include?(current_user) %>
+                            <%= form_tag(create_user_meal_path, method: :post) %>
+                            <%= hidden_field_tag 'meal_id', meal.id %>
+                            <%= submit_tag "Join This Meal!" %>
+                          <% end %>
+                        <% end %>
+                       </ul>
+                    </div> <!-- closes blog body -->
+                </div> <!-- closes blog blog info-->
+                <div class="blog blog-info">
+                  <div class="blog-header">
+                      <h5 class="blog-title">Already Attended:</h5>
+                  </div>
+                  <div class= "blog-body">
+                      <ul class="chats">
+                        <% if @past_meals.empty? %>
+                          <li>Has Never Attended Any Meals!</li>
+                        <% end %>
+                          <% @past_meals.each do |meal| %>
                           <li class="in">
                           <img class="avatar" alt src="<%= meal.host.image %>">
                           <div class="message">


### PR DESCRIPTION
some screenshots of what the changes look like: 

_hosting:_
![hosting](https://cloud.githubusercontent.com/assets/3201135/7359152/48e1bbec-ed09-11e4-9c5d-fa0501961a82.png)

_attending:_
![attending](https://cloud.githubusercontent.com/assets/3201135/7359158/557f0b3e-ed09-11e4-9ab3-e1a6b6eb92f4.png)

---

Bear in mind, I tested this with command-line-created users that weren't really created through the GitHub auth and only tried it out with ad-hoc `meals` and I don't have a full understanding of the app - so test this out a little with real data and make sure it plays nicely with existing live data. It should, since it's just using some `where` querying on `date`. but still.

You might want to check out if there is a layout difference now that I removed the `spacer` div, which looked like it was unclosed and may have been creating some weird indentation issue (although it was pretty harmless). Or I'm dumb and didn't realize how it was being used. Either way, it's in that one commit at the end and can be taken or left without changing the bulk of what this PR does.

:)
